### PR TITLE
CI: Add Ruby 3.1, bundler-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,22 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Rubocop
-        run: |
-          bin/setup
-          bin/ci-lint
+        run: bundle exec rubocop --format progress
 
   test:
     needs: [lint]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - '3.0'
+          - 3.1
 
     steps:
       - uses: actions/checkout@v2
@@ -41,11 +45,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Build
-        run: |
-          bin/setup
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Test
-        run: |
-          bin/ci-test
+        run: bundle exec rspec

--- a/bin/ci-lint
+++ b/bin/ci-lint
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle exec rubocop --format progress

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle exec rspec


### PR DESCRIPTION
This PR tries to simplify the CI matrix.

- Also: inline CI script files.
- Also: use another form of YAML list for the Ruby versions - this makes the diff smaller when adding/removing things from the list.