### PR TITLE
refactor: use Gemfile for development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,14 @@
 
 source 'https://rubygems.org'
 gemspec
+
+gem 'faraday', '~> 1.0'
+gem 'multipart-parser', '~> 0.1.1'
+gem 'rack-test', '>= 0.6'
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.0'
+gem 'rubocop', '~> 1.12.0'
+gem 'rubocop-packaging', '~> 0.5'
+gem 'rubocop-performance', '~> 1.0'
+gem 'simplecov', '~> 0.19.0'
+gem 'webmock', '~> 3.4'

--- a/faraday-rack.gemspec
+++ b/faraday-rack.gemspec
@@ -23,19 +23,4 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'faraday', '~> 1.0'
-  spec.add_development_dependency 'rack-test', '>= 0.6'
-
-  spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'simplecov', '~> 0.19.0'
-
-  spec.add_development_dependency 'multipart-parser', '~> 0.1.1'
-  spec.add_development_dependency 'webmock', '~> 3.4'
-
-  spec.add_development_dependency 'rubocop', '~> 1.12.0'
-  spec.add_development_dependency 'rubocop-packaging', '~> 0.5'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.0'
 end


### PR DESCRIPTION
This PR changes the way development dependencies are included in the build.

By having the development dependencies in the `Gemfile`, we have improved control over the versions picked during
tests, allowing us to run tests with variants, such as:

    gem 'faraday', '~> 2.0'

This PR changes none of the behaviour.