### PR TITLE
Depend on Faraday 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.5
           - 2.6
           - 2.7
           - '3.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'faraday', '~> 1.0'
 gem 'multipart-parser', '~> 0.1.1'
 gem 'rack-test', '>= 0.6'
 gem 'rake', '~> 13.0'

--- a/faraday-rack.gemspec
+++ b/faraday-rack.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'faraday', '~> 2.0'
 end

--- a/lib/faraday/adapter/rack.rb
+++ b/lib/faraday/adapter/rack.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rack/test'
+require 'timeout'
 
 module Faraday
   class Adapter
@@ -40,7 +41,7 @@ module Faraday
         timeout = request_timeout(:open, env[:request])
         timeout ||= request_timeout(:read, env[:request])
         response = if timeout
-                     Timer.timeout(timeout, Faraday::TimeoutError) do
+                     ::Timeout.timeout(timeout, Faraday::TimeoutError) do
                        execute_request(env, rack_env)
                      end
                    else

--- a/lib/faraday/rack.rb
+++ b/lib/faraday/rack.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'faraday'
 require 'faraday/adapter/rack'
 require 'faraday/rack/version'
 


### PR DESCRIPTION
This is a draft which relates to #2 

- Drop Ruby 2.5 from CI, Faraday 2.0 requires a newer Ruby


- [x] Fix issue with `Timer.timeout` - Timer not being found. It can be seen in the code for the Rack adapter in 0.9: https://github.com/lostisland/faraday/blob/0.9/lib/faraday/adapter/rack.rb#L44

```
              expected Faraday::TimeoutError, got #<NameError: uninitialized constant Faraday::Adapter::Rack::Timer> with backtrace:
                # ./lib/faraday/adapter/rack.rb:43:in `call'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/lib/faraday/middleware.rb:17:in `call'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/lib/faraday/request/url_encoded.rb:25:in `call'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/lib/faraday/rack_builder.rb:153:in `build_response'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/lib/faraday/connection.rb:445:in `run_request'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/lib/faraday/connection.rb:281:in `put'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/spec/support/shared_examples/request_method.rb:117:in `public_send'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/spec/support/shared_examples/request_method.rb:117:in `block (3 levels) in <top (required)>'
                # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/spec/support/shared_examples/request_method.rb:117:in `block (2 levels) in <top (required)>'
                # ./vendor/bundle/ruby/2.6.0/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
            # ./vendor/bundle/ruby/2.6.0/gems/faraday-2.2.0/spec/support/shared_examples/request_method.rb:117:in `block (2 levels) in <top (required)>'
            # ./vendor/bundle/ruby/2.6.0/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```