### PR TITLE
CI: Use Ruby 3.2, drop 2.x from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Ruby 2.7
+      - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.2
           bundler-cache: true # 'bundle install' and cache
 
       - name: Rubocop
@@ -33,13 +33,12 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.6
-          - 2.7
           - '3.0'
           - 3.1
+          - 3.2
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR removes old versions of Ruby from the matrix.