### PR TITLE
Set required_ruby_version to 2.6, match Faraday

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ plugins:
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   SuggestExtensions: false
   NewCops: enable
 

--- a/faraday-rack.gemspec
+++ b/faraday-rack.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday-rack'
   spec.license = 'MIT'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/lostisland/faraday-rack'

--- a/spec/support/webmock_rack_app.rb
+++ b/spec/support/webmock_rack_app.rb
@@ -41,7 +41,7 @@ class WebmockRackApp
 
   def req_headers(env)
     http_headers = env.select { |k, _| k.start_with?('HTTP_') }
-                      .map { |k, v| [k[5..-1], v] }
+                      .map { |k, v| [k[5..], v] }
                       .to_h
 
     http_headers.merge(env.slice(*Faraday::Adapter::Rack::SPECIAL_HEADERS))

--- a/spec/support/webmock_rack_app.rb
+++ b/spec/support/webmock_rack_app.rb
@@ -44,8 +44,7 @@ class WebmockRackApp
                       .map { |k, v| [k[5..-1], v] }
                       .to_h
 
-    special_headers = Faraday::Adapter::Rack::SPECIAL_HEADERS
-    http_headers.merge(env.select { |k, _| special_headers.include?(k) })
+    http_headers.merge(env.slice(*Faraday::Adapter::Rack::SPECIAL_HEADERS))
   end
 
   def req_body(env)

--- a/spec/support/webmock_rack_app.rb
+++ b/spec/support/webmock_rack_app.rb
@@ -41,8 +41,7 @@ class WebmockRackApp
 
   def req_headers(env)
     http_headers = env.select { |k, _| k.start_with?('HTTP_') }
-                      .map { |k, v| [k[5..], v] }
-                      .to_h
+                      .transform_keys { |k| k[5..] }
 
     http_headers.merge(env.slice(*Faraday::Adapter::Rack::SPECIAL_HEADERS))
   end


### PR DESCRIPTION
Faraday 2.0 had a ruby requirement of >= 2.6. This change makes no functional change, but keeps the metadata up-to-date, and easier to deal with.

https://rubygems.org/gems/faraday/versions/2.0.0